### PR TITLE
feat: expand values templating

### DIFF
--- a/charts/pvault-server/README.md
+++ b/charts/pvault-server/README.md
@@ -68,7 +68,7 @@ helm upgrade --install db bitnami/postgresql --namespace postgres --create-names
     --set-string auth.username=pvault \
     --set-string auth.password=pvault \
     --set-string auth.database=pvault \
-    --set primary.persistence.enabled=false 
+    --set primary.persistence.enabled=false
 ```
 
 Postgres will be available from within the cluster with the following hostname: `db-postgresql.postgres.svc.cluster.local`.
@@ -99,7 +99,7 @@ Use the following command line to deploy Piiano Vault Server on a typical Kubern
 2. Run:
 
   ```sh
-    helm upgrade --install pvault-server piiano/pvault-server \ 
+    helm upgrade --install pvault-server piiano/pvault-server \
       --create-namespace --namespace pvault \
       --set pvault.devmode=true \
       --set-string pvault.db.user=${DB_USER} \

--- a/charts/pvault-server/templates/_helpers.tpl
+++ b/charts/pvault-server/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 Expand the name of the chart.
 */}}
 {{- define "pvault-server.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name (tpl .Values.nameOverride .) | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 {{/*
@@ -13,10 +13,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "pvault-server.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- $fullNameRendered := tpl .Values.fullnameOverride . -}}
+{{- if $fullNameRendered -}}
+{{- $fullNameRendered | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name (tpl .Values.nameOverride .) -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -86,9 +87,9 @@ Create the name of the service account to use
 */}}
 {{- define "pvault-server.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "pvault-server.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "pvault-server.fullname" .) (tpl .Values.serviceAccount.name .) }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" (tpl .Values.serviceAccount.name .) }}
 {{- end }}
 {{- end }}
 
@@ -96,14 +97,14 @@ Create the name of the service account to use
 Get the name of an existing secret, or use default.
 */}}
 {{- define "pvault-server.secrets.name" }}
-{{- default (include "pvault-server.fullname" .context) .existingSecret }}
+{{- default (include "pvault-server.fullname" .context) (tpl .existingSecret .context) }}
 {{- end }}
 
 {{/*
 Get the key of an existing secret, or use default.
 */}}
 {{- define "pvault-server.secrets.key" }}
-{{- default .defaultSecretKey .existingSecretKey }}
+{{- default .defaultSecretKey (tpl .existingSecretKey .context) }}
 {{- end }}
 
 {{/*

--- a/charts/pvault-server/templates/configmap.yaml
+++ b/charts/pvault-server/templates/configmap.yaml
@@ -4,12 +4,12 @@
 {{- /* If dev psql is enabled, override Vault configurations. Otherwise, enforce them */}}
 {{- if .Values.postgresql.enabled }}
 {{- $dbHost = printf "%s-postgresql" .Chart.Name | quote }}
-{{- $dbName = default "pvault" .Values.postgresql.auth.database | quote }}
-{{- $dbUser = default "pvault" .Values.postgresql.auth.username | quote }}
+{{- $dbName = default "pvault" (tpl .Values.postgresql.auth.database .) | quote }}
+{{- $dbUser = default "pvault" (tpl .Values.postgresql.auth.username .) | quote }}
 {{- else }}
-{{- $dbHost = required "A valid .Values.pvault.db.hostname entry required!" .Values.pvault.db.hostname | quote }}
-{{- $dbName = required "A valid .Values.pvault.db.name entry required!" .Values.pvault.db.name | quote }}
-{{- $dbUser = required "A valid .Values.pvault.db.user entry required!" .Values.pvault.db.user | quote }}
+{{- $dbHost = required "A valid .Values.pvault.db.hostname entry required!" (tpl .Values.pvault.db.hostname .) | quote }}
+{{- $dbName = required "A valid .Values.pvault.db.name entry required!" (tpl .Values.pvault.db.name .) | quote }}
+{{- $dbUser = required "A valid .Values.pvault.db.user entry required!" (tpl .Values.pvault.db.user .) | quote }}
 {{- end }}
 kind: ConfigMap
 apiVersion: v1
@@ -66,8 +66,8 @@ data:
     custom_types_enable = {{ .Values.pvault.features.customTypesEnable }}
 
     [kms]
-    uri   = {{ .Values.pvault.kms.uri | quote }}
-    export_uri  = {{ .Values.pvault.kms.exportUri | quote }}
+    uri   = {{ tpl .Values.pvault.kms.uri . | quote }}
+    export_uri  = {{ tpl .Values.pvault.kms.exportUri . | quote }}
     {{- if kindIs "bool" .Values.pvault.kms.allow_local }}
     enable = {{ .Values.pvault.kms.allow_local }}
     {{ end }}
@@ -75,9 +75,9 @@ data:
     [log]
     level               = {{ .Values.pvault.log.level | quote }}
     datadog_apm_enable  = {{ .Values.pvault.log.datadogAPMEnable }}
-    customer_region     = {{ .Values.pvault.log.customerRegion | quote }}
-    customer_env        = {{ .Values.pvault.log.customerEnv | quote }}
-    customer_identifier = {{ required "A valid .Values.pvault.log.customerIdentifier is required." .Values.pvault.log.customerIdentifier | quote }}
+    customer_region     = {{ tpl .Values.pvault.log.customerRegion . | quote }}
+    customer_env        = {{ tpl .Values.pvault.log.customerEnv . | quote }}
+    customer_identifier = {{ required "A valid .Values.pvault.log.customerIdentifier is required." (tpl .Values.pvault.log.customerIdentifier .) | quote }}
   {{- with .Values.pvault.startupIAMFile }}
   pvault.iam.toml: |-
     {{- . | nindent 4 }}

--- a/charts/pvault-server/templates/deployment.yaml
+++ b/charts/pvault-server/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
             - name: DD_AGENT_HOST
               valueFrom:
                 fieldRef:
-                  fieldPath: status.hostIP    
+                  fieldPath: status.hostIP
           {{- end }}
           {{- with .Values.dbCARootCertificate }}
             - name: PGSSLROOTCERT

--- a/charts/pvault-server/templates/ingress.yaml
+++ b/charts/pvault-server/templates/ingress.yaml
@@ -23,14 +23,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl .secretName $ | quote }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
Allows secret names/keys, database parameters and ingress hosts to be templated from values.

Example:

```yaml
ingress:
  hosts:
    - host: "{{ .Release.Name }}.{{ .Values._domain }}"
```