### PR TITLE
fix: HPA metrics for K8S >= 1.23

### DIFF
--- a/charts/pvault-server/templates/hpa.yaml
+++ b/charts/pvault-server/templates/hpa.yaml
@@ -21,12 +21,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "pvault-server.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare "<1.23-0" (include "pvault-server.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes HPA metrics for Kubernetes >= 1.23.

