### PR TITLE
feat: set minReadySeconds by default

### DIFF
--- a/charts/pvault-server/templates/deployment.yaml
+++ b/charts/pvault-server/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
   {{- if .Values.updateStrategy }}
   strategy: {{ include "pvault-server.tplvalues.render" (dict "value" .Values.updateStrategy "context" .) | nindent 4 }}
   {{- end }}
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ include "pvault-server.tplvalues.render" (dict "value" .Values.minReadySeconds "context" .) }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/pvault-server/values.yaml
+++ b/charts/pvault-server/values.yaml
@@ -41,6 +41,10 @@ replicaCount: 1
 updateStrategy:
   type: RollingUpdate
 
+## @param minReadySeconds Minimum number of seconds for the pod to be considered available.
+##
+minReadySeconds: 10
+
 ## Piiano Vault Server image version.
 ## ref: https://hub.docker.com/r/piiano/pvault-server/tags
 image:


### PR DESCRIPTION
Sets `minReadySeconds` by default to 10 seconds.

It slows down pod rotation, ensuring that they are ready for at least 10 seconds, giving time for workers locks, etc to stabilize.
