### PR TITLE
feat: allow DB vars to be set from ENV

### DIFF
--- a/charts/pvault-server/templates/_helpers.tpl
+++ b/charts/pvault-server/templates/_helpers.tpl
@@ -154,3 +154,37 @@ Usage:
 {{- end -}}
 {{ $dst | toYaml }}
 {{- end -}}
+
+{{/*
+Validates if a key (name) exists in an ENV like object, K/V and list of env are supported.
+Usage:
+{{ include "pvault-server.env.exists" (dict "key" "MY_VAR" "context" .Values.pvault.extraEnvVars) }}
+*/}}
+{{- define "pvault-server.env.exists" -}}
+{{- /* Key/Value env vars */}}
+{{- if kindIs "map" $.context -}}
+  {{- if hasKey .context .key -}}
+    {{- true -}}
+  {{- end -}}
+{{- /* List of env objects */}}
+{{- else if kindIs "slice" $.context -}}
+  {{- $result := list -}}
+  {{- range $k, $v := $.context -}}
+    {{- $result = append $result (eq $v.name $.key) -}}
+  {{- end -}}
+  {{- if (has true $result) -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validates if a key (name) exists in ENV vars for the Vault container.
+Usage:
+{{ include "pvault-server.vault.env.exists" (dict "key" "MY_VAR" "context" $) }}
+*/}}
+{{- define "pvault-server.vault.env.exists" -}}
+{{- if or (include "pvault-server.env.exists" (dict "key" $.key "context" $.context.Values.pvault.extraEnvVars)) (include "pvault-server.env.exists" (dict "key" $.key "context" $.context.Values.pvault.extraEnv)) -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pvault-server/templates/configmap.yaml
+++ b/charts/pvault-server/templates/configmap.yaml
@@ -72,14 +72,14 @@ data:
     custom_types_enable = {{ .Values.pvault.features.customTypesEnable }}
 
     [kms]
-    {{- if kindIs "bool" .Values.pvault.kms.allow_local }}
-    enable = {{ .Values.pvault.kms.allow_local }}
-    {{- end }}
     {{- if .Values.pvault.kms.uri }}
-    uri = {{ tpl .Values.pvault.kms.uri . | quote }}
+    uri         = {{ tpl .Values.pvault.kms.uri . | quote }}
     {{- end }}
     {{- if .Values.pvault.kms.exportUri }}
-    export_uri = {{ tpl .Values.pvault.kms.exportUri . | quote }}
+    export_uri  = {{ tpl .Values.pvault.kms.exportUri . | quote }}
+    {{- end }}
+    {{- if kindIs "bool" .Values.pvault.kms.allow_local }}
+    allow_local = {{ .Values.pvault.kms.allow_local }}
     {{- end }}
 
     [log]

--- a/charts/pvault-server/templates/configmap.yaml
+++ b/charts/pvault-server/templates/configmap.yaml
@@ -1,15 +1,15 @@
 {{- $dbHost := "" }}
 {{- $dbName := "" }}
 {{- $dbUser := "" }}
-{{- /* If dev psql is enabled, override Vault configurations. Otherwise, enforce them */}}
+{{- /* If dev psql is enabled, override Vault configurations */}}
 {{- if .Values.postgresql.enabled }}
-{{- $dbHost = printf "%s-postgresql" .Chart.Name | quote }}
-{{- $dbName = default "pvault" (tpl .Values.postgresql.auth.database .) | quote }}
-{{- $dbUser = default "pvault" (tpl .Values.postgresql.auth.username .) | quote }}
+{{- $dbHost = printf "%s-postgresql" .Chart.Name }}
+{{- $dbName = default "pvault" (tpl .Values.postgresql.auth.database .) }}
+{{- $dbUser = default "pvault" (tpl .Values.postgresql.auth.username .) }}
 {{- else }}
-{{- $dbHost = required "A valid .Values.pvault.db.hostname entry required!" (tpl .Values.pvault.db.hostname .) | quote }}
-{{- $dbName = required "A valid .Values.pvault.db.name entry required!" (tpl .Values.pvault.db.name .) | quote }}
-{{- $dbUser = required "A valid .Values.pvault.db.user entry required!" (tpl .Values.pvault.db.user .) | quote }}
+{{- $dbHost = tpl .Values.pvault.db.hostname . }}
+{{- $dbName = tpl .Values.pvault.db.name . }}
+{{- $dbUser = tpl .Values.pvault.db.user . }}
 {{- end }}
 kind: ConfigMap
 apiVersion: v1
@@ -30,19 +30,25 @@ data:
     devmode = {{ .Values.pvault.devmode }}
 
     [db]
-    hostname    = {{ $dbHost }}
-    name        = {{ $dbName }}
-    user        = {{ $dbUser }}
+    {{- if $dbHost }}
+    hostname    = {{ $dbHost | quote }}
+    {{- end }}
+    {{- if $dbName }}
+    name        = {{ $dbName | quote }}
+    {{- end }}
+    {{- if $dbUser }}
+    user        = {{ $dbUser | quote }}
+    {{- end }}
     port        = {{ .Values.pvault.db.port }}
     {{- if kindIs "bool" .Values.pvault.db.requireTLS }}
     require_tls = {{ .Values.pvault.db.requireTLS }}
-    {{ end }}
+    {{- end }}
 
     [service]
     listen_addr             = "0.0.0.0:8123"
     {{- if kindIs "bool" .Values.pvault.app.adminMayReadData }}
     admin_may_read_data     = {{ .Values.pvault.app.adminMayReadData }}
-    {{ end }}
+    {{- end }}
     timeout_seconds         = {{ .Values.pvault.app.timeoutSeconds }}
     cache_refresh_interval_seconds = {{ .Values.pvault.app.cacheRefreshIntervalSeconds }}
     default_page_size       = {{ .Values.pvault.app.defaultPageSize }}
@@ -53,7 +59,7 @@ data:
     [tls]
     {{- if kindIs "bool" .Values.pvault.tls.enable }}
     enable = {{ .Values.pvault.tls.enable }}
-    {{ end }}
+    {{- end }}
     cert_file   = {{ .Values.pvault.tls.certFile | quote }}
     key_file    = {{ .Values.pvault.tls.keyFile | quote }}
     selfsigned  = {{ .Values.pvault.tls.selfsigned }}
@@ -66,11 +72,15 @@ data:
     custom_types_enable = {{ .Values.pvault.features.customTypesEnable }}
 
     [kms]
-    uri   = {{ tpl .Values.pvault.kms.uri . | quote }}
-    export_uri  = {{ tpl .Values.pvault.kms.exportUri . | quote }}
     {{- if kindIs "bool" .Values.pvault.kms.allow_local }}
     enable = {{ .Values.pvault.kms.allow_local }}
-    {{ end }}
+    {{- end }}
+    {{- if .Values.pvault.kms.uri }}
+    uri = {{ tpl .Values.pvault.kms.uri . | quote }}
+    {{- end }}
+    {{- if .Values.pvault.kms.exportUri }}
+    export_uri = {{ tpl .Values.pvault.kms.exportUri . | quote }}
+    {{- end }}
 
     [log]
     level               = {{ .Values.pvault.log.level | quote }}


### PR DESCRIPTION
Allows some settings to be set from ENV vars by removing the Helm `required` attribute and conditionally setting the values in the TOML configMap.

Provides flexibility around templating for advanced setups.

Example sourcing DB username from a secret:

```yaml
pvault:
  extraEnv:
    - name: PVAULT_DB_USER
      valueFrom:
        secretKeyRef:
          name: my-database-secret
          key: username
```

- [x] Depends on https://github.com/piiano/helm-charts/pull/40
